### PR TITLE
Sanitize pom to pass Nexus rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.classpath
+.project
+.settings
+.DS_Store
 *.class
 
 target/**

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ for Maven, you can add the follwing sections to your POM.XML:
 
   <dependencies>
     <dependency>
-      <groupId>com.github.multiformats</groupId>
-      <artifactId>java-multibase</artifactId>
-      <version>v1.0.0</version>
+      <groupId>io.ipfs</groupId>
+      <artifactId>multibase</artifactId>
+      <version>v1.0.1</version>
     </dependency>
   </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,14 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
+    <name>Multibase</name>
+    
 	<groupId>io.ipfs</groupId>
 	<artifactId>multibase</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
-	<name>multibase</name>
+    <description>A Java implementation of multibase</description>
 	<url>https://github.com/multiformats/java-multibase</url>
 
  	<issueManagement>
@@ -32,21 +34,21 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<junit.version>4.12</junit.version>
-		<hamcrest.version>1.3</hamcrest.version>
+        <version.hamcrest>1.3</version.hamcrest>
+        <version.junit>4.12</version.junit>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
+			<version>${version.junit}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>
-			<version>${hamcrest.version}</version>
+			<version>${version.hamcrest}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -79,6 +81,21 @@
 					</archive>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
+
+    <developers>
+        <developer>
+            <name>Multiformats Committers</name>
+        </developer>
+    </developers>
+    
 </project>


### PR DESCRIPTION
Jitpack works fine as the remote mvn repository. However, building the latest from master should use *-SNAPSHOT and not override the latest stable release in the local mvn repo.