### PR TITLE
Managing versions of Java multiformats on Maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.classpath
+.project
+.settings
 *.class
 
 target/**

--- a/pom.xml
+++ b/pom.xml
@@ -2,9 +2,9 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>io.ipfs</groupId>
-	<artifactId>multibase</artifactId>
-	<version>1.0.0</version>
+	<groupId>com.github.multiformats</groupId>
+	<artifactId>java-multibase</artifactId>
+	<version>v1.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>multibase</name>
@@ -32,23 +32,23 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<junit.version>4.12</junit.version>
-		<hamcrest.version>1.3</hamcrest.version>
+        <version.junit>4.12</version.junit>
+        <version.hamcrest>1.3</version.hamcrest>
 	</properties>
 
 	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>${hamcrest.version}</version>
-			<scope>test</scope>
-		</dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${version.junit}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${version.hamcrest}</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Currently there is some confusion around groupId+artifactId and what jitpack is using. For maven builds, its important that these align.

JitPack releases like this

```
        <dependency>
            <groupId>com.github.multiformats</groupId>
            <artifactId>java-multibase</artifactId>
            <version>${version.multibase}</version>
        </dependency>
```

which should also be the identity of the artifact in the pom. Alternatively, it may be possible to tweak JitPack to release with identity currently given in the pom.