### PR TITLE
remove base1

### DIFF
--- a/src/main/java/io/ipfs/multibase/Multibase.java
+++ b/src/main/java/io/ipfs/multibase/Multibase.java
@@ -7,7 +7,6 @@ public class Multibase {
 
     public enum Base {
         // encoding(code)
-        Base1('1'), // unary tends to be 11111
         Base2('0'), // binary has 1 and 0
         Base8('7'), // highest char in octal
         Base10('9'), // highest char in decimal


### PR DESCRIPTION
Base1 has been removed from the spec for compatibility/uselessness reasons:
* https://github.com/multiformats/multibase/pull/57
* https://github.com/multiformats/multibase/pull/47