### PR TITLE
Custom types for known exceptions

### DIFF
--- a/src/main/java/io/ipfs/multibase/Multibase.java
+++ b/src/main/java/io/ipfs/multibase/Multibase.java
@@ -22,14 +22,15 @@ public class Multibase {
         }
 
         private static Map<Character, Base> lookup = new TreeMap<>();
+
         static {
-            for (Base b: Base.values())
+            for (Base b : Base.values())
                 lookup.put(b.prefix, b);
         }
 
         public static Base lookup(char p) {
             if (!lookup.containsKey(p))
-                throw new IllegalStateException("Unknown Multibase type: " + p);
+                throw new UnknownCodeException(p);
             return lookup.get(p);
         }
     }
@@ -43,7 +44,7 @@ public class Multibase {
             case Base32:
                 return b.prefix + Base32.encode(data);
             default:
-                throw new IllegalStateException("Unsupported base encoding: " + b.name());
+                throw new UnsupportedEncodingException(b);
         }
     }
 
@@ -62,7 +63,8 @@ public class Multibase {
             case Base32:
                 return Base32.decode(rest);
             default:
-                throw new IllegalStateException("Unsupported base encoding: " + b.name());
+                throw new UnsupportedEncodingException(b);
         }
     }
+
 }

--- a/src/main/java/io/ipfs/multibase/UnknownCodeException.java
+++ b/src/main/java/io/ipfs/multibase/UnknownCodeException.java
@@ -1,0 +1,18 @@
+package io.ipfs.multibase;
+
+public class UnknownCodeException extends IllegalStateException {
+    private final char code;
+
+    public UnknownCodeException(char code) {
+        this.code = code;
+    }
+
+    public char getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Unknown Multibase type: " + code;
+    }
+}

--- a/src/main/java/io/ipfs/multibase/UnsupportedEncodingException.java
+++ b/src/main/java/io/ipfs/multibase/UnsupportedEncodingException.java
@@ -1,0 +1,18 @@
+package io.ipfs.multibase;
+
+public class UnsupportedEncodingException extends IllegalStateException {
+    private final Multibase.Base base;
+
+    public UnsupportedEncodingException(Multibase.Base base) {
+        this.base = base;
+    }
+
+    public Multibase.Base getBase() {
+        return base;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Unsupported base encoding: " + base.name();
+    }
+}


### PR DESCRIPTION
Custom exception types for known error conditions make it easier to handle these conditions with fine-grained catch blocks. I made the new types extend `IllegalStateException` so that this change doesn't affect any old code that might catch that error type.