### PR TITLE
Organised checks for bad inputs, and added a couple test cases.

### DIFF
--- a/src/main/java/io/ipfs/multibase/Base16.java
+++ b/src/main/java/io/ipfs/multibase/Base16.java
@@ -3,7 +3,7 @@ package io.ipfs.multibase;
 public class Base16 {
     public static byte[] decode(String hex) {
         if (hex.length() % 2 == 1)
-            throw new IllegalStateException("Must have an even number of hex digits to convert to bytes!");
+            throw new IllegalArgumentException("Must have an even number of hex digits to convert to bytes!");
         byte[] res = new byte[hex.length()/2];
         for (int i=0; i < res.length; i++)
             res[i] = (byte) Integer.parseInt(hex.substring(2*i, 2*i+2), 16);

--- a/src/main/java/io/ipfs/multibase/Base58.java
+++ b/src/main/java/io/ipfs/multibase/Base58.java
@@ -106,7 +106,7 @@ public class Base58 {
             char c = input.charAt(i);
             int digit = c < 128 ? INDEXES[c] : -1;
             if (digit < 0) {
-                throw new IllegalStateException("InvalidCharacter in base 58");
+                throw new IllegalArgumentException(String.format("Invalid character in Base58: 0x%04x", (int) c));
             }
             input58[i] = (byte) digit;
         }

--- a/src/main/java/io/ipfs/multibase/Multibase.java
+++ b/src/main/java/io/ipfs/multibase/Multibase.java
@@ -45,7 +45,7 @@ public class Multibase {
 
         public static Base lookup(char p) {
             if (!lookup.containsKey(p))
-                throw new IllegalStateException("Unknown Multibase type: " + p);
+                throw new IllegalArgumentException("Unknown Multibase type: " + p);
             return lookup.get(p);
         }
     }
@@ -87,7 +87,7 @@ public class Multibase {
             case Base64UrlPad:
                 return b.prefix + Base64.encodeBase64String(data).replaceAll("\\+", "-").replaceAll("/", "_");
             default:
-                throw new IllegalStateException("Unsupported base encoding: " + b.name());
+                throw new UnsupportedOperationException("Unsupported base encoding: " + b.name());
         }
     }
 
@@ -96,6 +96,9 @@ public class Multibase {
     }
 
     public static byte[] decode(String data) {
+        if(data.isEmpty()) {
+            throw new IllegalArgumentException("Cannot decode an empty string");
+        }
         Base b = encoding(data);
         String rest = data.substring(1);
         switch (b) {
@@ -127,7 +130,7 @@ public class Multibase {
             case Base64UrlPad:
                 return Base64.decodeBase64(rest);
             default:
-                throw new IllegalStateException("Unsupported base encoding: " + b.name());
+                throw new UnsupportedOperationException("Unsupported base encoding: " + b.name());
         }
     }
 }

--- a/src/test/java/io/ipfs/multibase/MultibaseBadInputsTest.java
+++ b/src/test/java/io/ipfs/multibase/MultibaseBadInputsTest.java
@@ -1,24 +1,33 @@
 package io.ipfs.multibase;
 
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class MultibaseBadInputsTest {
 
-    @Test
-    public void invalidBase16Test() {
-        String example = "f012"; // hex string of odd length
-        try {
-            byte[] output = Multibase.decode(example);
-            throw new RuntimeException();
-        } catch (IllegalStateException e) {
-            // expect error
-        }
+    @Parameter
+    public String input;
+
+    @Parameters(name = "{index}: \"{0}\"")
+    public static Collection<String> data() {
+        return Arrays.asList(
+            "f012", // Hex string of odd length, not allowed in Base16
+            "f0g", // 'g' char is not allowed in Base16
+            "zt1Zv2yaI", // 'I' char is not allowed in Base58
+            "2", // '2' is not a valid encoding marker
+            "" // Empty string is not a valid multibase
+        );
     }
 
-    @Test (expected = NumberFormatException.class)
-    public void invalidWithExceptionBase16Test() {
-        String example = "f0g"; // g char is not allowed in hex
-        Multibase.decode(example);
+    @Test (expected = IllegalArgumentException.class)
+    public void badInputTest() {
+        Multibase.decode(input);
     }
 
 }


### PR DESCRIPTION
According to the Java documentation, [`IllegalArgumentException`](https://docs.oracle.com/javase/8/docs/api/java/lang/IllegalArgumentException.html) (or a subclass thereof) should be thrown when the method receives an inappropriate argument. If the argument or action is valid in theory, but not supported by the current implementation, [`UnsupportedOperationException`](https://docs.oracle.com/javase/8/docs/api/java/lang/UnsupportedOperationException.html) seems to be more appropriate. On the other hand, [`IllegalStateException`](https://docs.oracle.com/javase/8/docs/api/java/lang/IllegalStateException.html) should mean that the method is called "at an appropriate time", but it is also often used in a state that "cannot possibly happen".

An empty string doesn't seem to be a valid input for Multibase decoding, as it doesn't have an encoding marker.

Having changed all the input checks to throw the same type of exception, it is now possible to convert `MultibaseBadInputsTest` into a parameterised test, in which only the input changes.