### PR TITLE
module-info.java for modular java projects

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module io.ipfs.multibase {
+    exports io.ipfs.multibase;
+    exports io.ipfs.multibase.binary;
+}


### PR DESCRIPTION
Hello,

Dear authors, thank you for this useful library.
In my company we would like to use `java-multibase` library with a modular java project.
In this PR I added exports to the `module-info.java` file.
This will eliminate the following warning when compiling the JPMS projects:
```
Required filename-based automodules detected: [java-multibase-1.1.1.jar]. Please don't publish this project to a public artifact repository!
```

Can you verify that these changes are sufficient?