### PR TITLE
Use Maven in the Github workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,8 +14,8 @@ jobs:
       with:
         distribution: temurin
         java-version: 11
-    - name: Build with Ant
-      run: ant -noinput -buildfile build.xml dist
+    - name: Build with Maven
+      run: mvn -B test-compile
     - name: Run tests
       timeout-minutes: 10
-      run: ant -noinput -buildfile build.xml test
+      run: mvn -B test


### PR DESCRIPTION
Hello,

In the last PR I broke the Github workflow.
In this PR, I fix it by using Maven to build and test the project.
