### PR TITLE
Migrate JUnit4 -> JUnit5, update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ byte[] decoded = Multibase.decode(encoded);
 You can use this project by building the JAR file as specified below, or by using [JitPack](https://jitpack.io/#multiformats/java-multibase/) (also supporting Gradle, SBT, etc).
 
 for Maven, you can add the follwing sections to your POM.XML:
-```
+```xml
   <repositories>
     <repository>
         <id>jitpack.io</id>
@@ -48,7 +48,8 @@ for Maven, you can add the follwing sections to your POM.XML:
 `mvn package` will build a JAR file with Maven dependency information.
 
 ## Releasing
-The version number is specified in the `pom.xml` and must be changed in both places in order to be accurately reflected in the JAR file manifest. A git tag must be added in the format "vx.x.x" for JitPack to work.
+
+The version number is specified in the `pom.xml` file and must be changed in order to be accurately reflected in the JAR file manifest. A git tag must be added in the format "vx.x.x" for JitPack to work.
 
 ## Maintainers
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,14 +32,14 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.junit>4.13.2</version.junit>
-        <version.hamcrest>2.2</version.hamcrest>
+        <version.junit>5.11.0</version.junit>
+        <version.hamcrest>3.0</version.hamcrest>
 	</properties>
 
 	<dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>3.3.1</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/test/java/io/ipfs/multibase/MultibaseBadInputsTest.java
+++ b/src/test/java/io/ipfs/multibase/MultibaseBadInputsTest.java
@@ -2,19 +2,14 @@ package io.ipfs.multibase;
 
 import java.util.Arrays;
 import java.util.Collection;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
 
-@RunWith(Parameterized.class)
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class MultibaseBadInputsTest {
 
-    @Parameter
-    public String input;
-
-    @Parameters(name = "{index}: \"{0}\"")
     public static Collection<String> data() {
         return Arrays.asList(
             "f012", // Hex string of odd length, not allowed in Base16
@@ -25,9 +20,12 @@ public class MultibaseBadInputsTest {
         );
     }
 
-    @Test (expected = IllegalArgumentException.class)
-    public void badInputTest() {
-        Multibase.decode(input);
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: \"{0}\"")
+    public void badInputTest(String input) {
+        assertThrows(IllegalArgumentException.class, () -> {
+            Multibase.decode(input);
+        });
     }
 
 }

--- a/src/test/java/io/ipfs/multibase/MultibaseTest.java
+++ b/src/test/java/io/ipfs/multibase/MultibaseTest.java
@@ -1,30 +1,16 @@
 package io.ipfs.multibase;
 
-import org.junit.Test;
-
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-@RunWith(Parameterized.class)
 public class MultibaseTest {
 
-    private Multibase.Base base;
-    private byte[] raw;
-    private String encoded;
-
-    public MultibaseTest(Multibase.Base base, byte[] raw, String encoded) {
-        this.base = base;
-        this.raw = raw;
-        this.encoded = encoded;
-    }
-
-    @Parameters(name = "{index}: {0}, {2}")
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][]{
                 {Multibase.Base.Base58BTC, hexToBytes("1220120F6AF601D46E10B2D2E11ED71C55D25F3042C22501E41D1246E7A1E9D3D8EC"), "zQmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB"},
@@ -64,16 +50,18 @@ public class MultibaseTest {
         });
     }
 
-    @Test
-    public void testEncode() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: {0}, {2}")
+    public void testEncode(Multibase.Base base, byte[] raw, String encoded) {
         String output = Multibase.encode(base, raw);
         assertEquals(encoded, output);
     }
 
-    @Test
-    public void testDecode() {
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: {0}, {2}")
+    public void testDecode(Multibase.Base base, byte[] raw, String encoded) {
         byte[] output = Multibase.decode(encoded);
-        assertArrayEquals(String.format("Expected %s, but got %s", bytesToHex(raw), bytesToHex(output)), raw, output);
+        assertArrayEquals(raw, output, String.format("Expected %s, but got %s", bytesToHex(raw), bytesToHex(output)));
     }
 
     //Copied from https://stackoverflow.com/a/140861


### PR DESCRIPTION
The junit5 framework is the successor to junit4, and is maintained by the authors.
Changes in this PR:
- Tests migrated from JUnit4 to JUnit5 using OpenRewrite
- Dependencies updated