### PR TITLE
Fix JitPack build: Install latest Maven and Java

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sdk install java 21-tem
+  - sdk install maven


### PR DESCRIPTION
It looks like the latest jitpack compilation [failed](https://jitpack.io/com/github/multiformats/java-multibase/v1.2.0/build.log).
It's caused by the old versions of Maven and Java:

- `Apache Maven 3.6.1` - 2019-04-04
- `Java version: 11.0.2`

In this PR I update Maven to the latest version and enable compilation with the latest java LTS (project is still targeted for Java 11)