### PR TITLE
JitPack build: Use Java 21

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,3 +1,4 @@
 before_install:
   - sdk install java 21-tem
+  - sdk use java 21-tem
   - sdk install maven


### PR DESCRIPTION
I forgot to call `sdk use java 21-tem` to set the currently used Java version.  
After changes in this PR, the build prints the latest Maven and Java 21 to the output - as expected:
```
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /home/jitpack/.sdkman/candidates/maven/current
Java version: 21, vendor: Eclipse Adoptium, runtime: /home/jitpack/.sdkman/candidates/java/21-tem
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "4.10.0-28-generic", arch: "amd64", family: "unix"
```
[link to output](https://jitpack.io/com/github/mk868/java-multibase/jitpack-build-SNAPSHOT/build.log)